### PR TITLE
Add timeline indicator for workout phases

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,6 +95,10 @@
                 <div class="progress-bar" id="progressBar" style="width: 0%"></div>
             </div>
 
+            <div class="timeline" id="timeline">
+                <div class="timeline-indicator" id="timelineIndicator"></div>
+            </div>
+
             <div class="audio-visualization" id="audioVisualization">
                 <!-- Audio bars will be added dynamically -->
             </div>

--- a/index.html
+++ b/index.html
@@ -91,11 +91,8 @@
 
             <div class="timer-display" id="timerDisplay">00:00</div>
 
-            <div class="progress-container">
-                <div class="progress-bar" id="progressBar" style="width: 0%"></div>
-            </div>
-
             <div class="timeline" id="timeline">
+                <div class="timeline-progress" id="progressBar" style="width: 0%"></div>
                 <div class="timeline-indicator" id="timelineIndicator"></div>
             </div>
 

--- a/main.css
+++ b/main.css
@@ -355,6 +355,56 @@ h1 {
     background: linear-gradient(90deg, #4361ee, #3a0ca3);
 }
 
+/* Timeline */
+.timeline {
+    width: 100%;
+    height: 12px;
+    background-color: #e9ecef;
+    border-radius: 20px;
+    position: relative;
+    display: flex;
+    overflow: hidden;
+    margin: 0.5rem 0 1rem;
+}
+
+.timeline-segment {
+    height: 100%;
+}
+
+.timeline-run {
+    background-color: var(--danger-color);
+}
+
+.timeline-walk {
+    background-color: var(--warning-color);
+}
+
+.timeline-warmUp {
+    background-color: #fff9c4;
+}
+
+.timeline-coolDown {
+    background-color: #bbdefb;
+}
+
+.timeline-segment.active {
+    opacity: 0.6;
+}
+
+.timeline-indicator {
+    position: absolute;
+    top: -2px;
+    bottom: -2px;
+    width: 2px;
+    background-color: var(--text-color);
+    left: 0;
+    transition: left 1s linear;
+}
+
+.dark-mode .timeline-indicator {
+    background-color: #f8f9fa;
+}
+
 .next-phase-preview {
     display: none; /* Hidden by default */
     text-align: center;

--- a/main.css
+++ b/main.css
@@ -329,31 +329,6 @@ h1 {
     border-radius: var(--btn-radius);
 }
 
-.progress-container {
-    width: 100%;
-    height: 12px;
-    background-color: #e9ecef;
-    border-radius: 20px;
-    margin: 1.5rem 0;
-    overflow: hidden;
-}
-
-.progress-bar {
-    height: 100%;
-    background: linear-gradient(90deg, var(--primary-color), var(--secondary-color));
-    border-radius: 20px;
-    transition: width 1s linear;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: white;
-    font-size: 0.7rem;
-    font-weight: 600;
-}
-
-.dark-mode .progress-bar {
-    background: linear-gradient(90deg, #4361ee, #3a0ca3);
-}
 
 /* Timeline */
 .timeline {
@@ -365,6 +340,30 @@ h1 {
     display: flex;
     overflow: hidden;
     margin: 0.5rem 0 1rem;
+}
+
+.timeline-progress {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 0;
+    background: linear-gradient(90deg, var(--primary-color), var(--secondary-color));
+    border-radius: 20px;
+    transition: width 1s linear;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-size: 0.7rem;
+    font-weight: 600;
+    pointer-events: none;
+    z-index: 1;
+    opacity: 0.8;
+}
+
+.dark-mode .timeline-progress {
+    background: linear-gradient(90deg, #4361ee, #3a0ca3);
 }
 
 .timeline-segment {
@@ -929,9 +928,6 @@ label {
     color: #90e0ef;
 }
 
-.dark-mode .progress-bar {
-    background: linear-gradient(90deg, #4361ee, #3a0ca3);
-}
 
 .achievements {
     margin-top: 2rem;

--- a/main.css
+++ b/main.css
@@ -353,8 +353,9 @@ h1 {
     transition: width 1s linear;
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-end;
     color: white;
+    mix-blend-mode: difference;
     font-size: 0.7rem;
     font-weight: 600;
     pointer-events: none;
@@ -363,7 +364,7 @@ h1 {
 }
 
 .dark-mode .timeline-progress {
-    background: linear-gradient(90deg, #4361ee, #3a0ca3);
+    background: linear-gradient(90deg, rgba(67, 98, 238, 0.205), rgba(57, 12, 163, 0.205));
 }
 
 .timeline-segment {
@@ -396,6 +397,7 @@ h1 {
     bottom: -2px;
     width: 2px;
     background-color: var(--text-color);
+    mix-blend-mode: difference;
     left: 0;
     transition: left 1s linear;
 }

--- a/main.js
+++ b/main.js
@@ -1249,19 +1249,26 @@ function updateWorkoutInfo() {
         // Render timeline for selected workout
         renderTimeline(workout.schedule);
         timelineIndicator.style.left = '0%';
+        progressBar.style.width = '0%';
+        progressBar.textContent = '';
     } else {
         workoutTitle.textContent = 'Select a Workout';
         workoutDescription.textContent = 'Choose a week and workout to begin your C25K training program.';
 
         // Clear timeline if no workout selected
         timeline.innerHTML = '';
+        timeline.appendChild(progressBar);
+        timeline.appendChild(timelineIndicator);
         timelineIndicator.style.left = '0%';
+        progressBar.style.width = '0%';
+        progressBar.textContent = '';
     }
 }
 
 // Render the timeline segments based on the workout schedule
 function renderTimeline(schedule) {
     timeline.innerHTML = '';
+    timeline.appendChild(progressBar);
     schedule.forEach((phase, index) => {
         const segment = document.createElement('div');
         segment.classList.add('timeline-segment', `timeline-${phase.type}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "C25K",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Summary
- show a phase timeline in the workout card
- style timeline segments for run/walk/warm-up/cool-down
- render timeline segments for selected workout and highlight current phase
- move an indicator across the timeline as the workout progresses

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_6840da4f41888330be7eb77c0dc4673f